### PR TITLE
Fix/naver login

### DIFF
--- a/src/api/fetcher/user.ts
+++ b/src/api/fetcher/user.ts
@@ -7,3 +7,8 @@ export const loginNaver = async (requestDataLoginNaver: IRequestLoginNaver) => {
 
   return data;
 };
+
+export const getUserInfo = async () => {
+  const { data } = await API.get('/user');
+  return data;
+};

--- a/src/api/fetcher/users.ts
+++ b/src/api/fetcher/users.ts
@@ -1,4 +1,4 @@
-import { IUser } from './../types/users/index';
+import { IUser } from '../types/users/index';
 import { API } from '..';
 import { IRequestLoginNaver } from '../types/users';
 
@@ -8,7 +8,8 @@ export const loginNaver = async (requestDataLoginNaver: IRequestLoginNaver) => {
   return data;
 };
 
-export const getUserInfo = async () => {
-  const { data } = await API.get('/user');
+export const getUserInfo = async (id: number) => {
+  const { data } = await API.get<IUser>(`/users/${id}`);
+
   return data;
 };

--- a/src/api/hook/users.ts
+++ b/src/api/hook/users.ts
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query';
+import { getUserInfo } from '../fetcher/users';
+
+const QUERY_KEY = {
+  USERS: 'USERS',
+};
+
+export const useUser = (id: number) => {
+  return useQuery([QUERY_KEY.USERS, id], () => getUserInfo(id), {
+    enabled: !!id,
+  });
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,7 +2,7 @@ import { API_END_POINT } from './../constants/index';
 import axios from 'axios';
 const local = 'http://localhost:3001';
 
-export const API = axios.create({ baseURL: local });
+export const API = axios.create({ baseURL: local, withCredentials: true });
 
 export interface IPagination<T> {
   page: number;

--- a/src/components/common/header/header.tsx
+++ b/src/components/common/header/header.tsx
@@ -6,9 +6,10 @@ import LogoIcon from '../@Icons/logoIcon';
 import LoginIcon from '../@Icons/loginIcon';
 import SearchBar from '../searchbar/searchBar';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { loginPopupState, loginState } from '../../../recoils/login';
+import { loginPopupState } from '../../../recoils/atoms/users';
 import LoginPopUp from '../../login/login-pop-up';
 import Button from '../button';
+import { loginState } from '../../../recoils/selector/users';
 
 const Header = () => {
   const { pathname, push } = useRouter();

--- a/src/components/detail/comments/index.tsx
+++ b/src/components/detail/comments/index.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { IComment } from '../../../api/types/beers';
-import { loginPopupState, loginState } from '../../../recoils/login';
+import { loginPopupState } from '../../../recoils/atoms/users';
+import { loginState } from '../../../recoils/selector/users';
 import { EmptyFallback } from '../../../styles/mypage/rates';
 import { dateFormat } from '../../../utils/dateFormat';
 import EmptyIcon from '../../common/@Icons/emptyIcon';
@@ -20,7 +21,7 @@ const DetailComments = ({ datas }: { datas: any }) => {
         <Title>한줄평</Title>
         <Button
           onClick={() => {
-            if (isLogin) setInputOpen(_prev => !_prev);
+            if (!!isLogin) setInputOpen(_prev => !_prev);
             else setLoginPopupState(true);
           }}
         >

--- a/src/components/login/login-pop-up/index.tsx
+++ b/src/components/login/login-pop-up/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
 import { NAVER_CLIENT_ID, NAVER_REDIRECT_URL } from '../../../constants';
-import { loginPopupState } from '../../../recoils/login';
+import { loginPopupState } from '../../../recoils/atoms/users';
 import AnimatedLogoIcon from '../../common/@Icons/animated-logo/animatedLogoIcon';
 import KakaoIcon from '../../common/@Icons/kakaoIcon';
 import NaverIcon from '../../common/@Icons/naverIcon';

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -33,7 +33,7 @@ const Detail = () => {
     if (inView && hasNextPage) {
       fetchNextPage();
     }
-  }, [inView, hasNextPage]);
+  }, [inView, hasNextPage, fetchNextPage]);
 
   if (!beer) return null;
   return (

--- a/src/pages/list.tsx
+++ b/src/pages/list.tsx
@@ -31,7 +31,7 @@ const List = () => {
     if (inView && hasNextPage) {
       fetchNextPage();
     }
-  }, [inView, hasNextPage]);
+  }, [inView, hasNextPage, fetchNextPage]);
 
   return (
     <ListContanier>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -12,18 +12,24 @@ import {
   ProfileImage,
   Section,
 } from '../../styles/mypage';
+import { useRecoilValue } from 'recoil';
+import { userIdState } from '../../recoils/atoms/users';
+import { useUser } from '../../api/hook/users';
 
 const background = '#F8F7F5';
 const tertiary = '#F0E5CF';
 const Mypage = () => {
+  const userId = useRecoilValue(userIdState);
+  if (!userId) return null;
+  const { data } = useUser(userId);
   const router = useRouter();
   return (
     <Section>
       <ProfileContainer>
         <ProfileImage src="https://picsum.photos/200" alt="" />
         <ProfileDescription>
-          <Nickname>닉네임우하하</Nickname>
-          <Email>mail@email.com</Email>
+          <Nickname>{data?.nickname}</Nickname>
+          <Email>{data?.email}</Email>
           <Button
             primary
             size="small"

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -20,9 +20,9 @@ const background = '#F8F7F5';
 const tertiary = '#F0E5CF';
 const Mypage = () => {
   const userId = useRecoilValue(userIdState);
-  if (!userId) return null;
-  const { data } = useUser(userId);
+  const { data } = useUser(userId as number);
   const router = useRouter();
+
   return (
     <Section>
       <ProfileContainer>

--- a/src/pages/oauth/naver.tsx
+++ b/src/pages/oauth/naver.tsx
@@ -5,15 +5,14 @@ import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { loginNaver } from '../../api/fetcher/user';
 import { SITE_URL } from '../../constants';
-import { loginState, userInfoState } from '../../recoils/login';
+import { userIdState } from '../../recoils/atoms/users';
 
 const OauthNaver = ({ user }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const setUserInfoState = useSetRecoilState(userInfoState);
-  const setLoignState = useSetRecoilState(loginState);
+  const setuserIdState = useSetRecoilState(userIdState);
   const router = useRouter();
   useEffect(() => {
-    setUserInfoState(user);
-    setLoignState(true);
+    setuserIdState(user.id);
+
     router.replace('/');
   }, []);
   return <div />;

--- a/src/pages/oauth/naver.tsx
+++ b/src/pages/oauth/naver.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { loginNaver } from '../../api/fetcher/users';
 import { SITE_URL } from '../../constants';
@@ -10,16 +10,6 @@ import { userIdState } from '../../recoils/atoms/users';
 const OauthNaver = ({ data }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const setuserIdState = useSetRecoilState(userIdState);
   const router = useRouter();
-  // const {
-  //   query: { code, state },
-  // } = router;
-  // const data = useMemo(() => {
-  //   return {
-  //     code: code as string,
-  //     redirectUri: `${SITE_URL}/oauth/naver`,
-  //     state: state as string,
-  //   };
-  // }, [code, state]);
 
   useEffect(() => {
     async function loginWithNaver() {
@@ -27,8 +17,8 @@ const OauthNaver = ({ data }: InferGetServerSidePropsType<typeof getServerSidePr
       setuserIdState(user.id);
     }
 
-    //loginWithNaver();
-    console.log(data);
+    loginWithNaver();
+
     router.replace('/');
   }, []);
   return <div />;

--- a/src/pages/oauth/naver.tsx
+++ b/src/pages/oauth/naver.tsx
@@ -1,18 +1,34 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { loginNaver } from '../../api/fetcher/user';
+import { loginNaver } from '../../api/fetcher/users';
 import { SITE_URL } from '../../constants';
 import { userIdState } from '../../recoils/atoms/users';
 
-const OauthNaver = ({ user }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const OauthNaver = ({ data }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const setuserIdState = useSetRecoilState(userIdState);
   const router = useRouter();
-  useEffect(() => {
-    setuserIdState(user.id);
+  // const {
+  //   query: { code, state },
+  // } = router;
+  // const data = useMemo(() => {
+  //   return {
+  //     code: code as string,
+  //     redirectUri: `${SITE_URL}/oauth/naver`,
+  //     state: state as string,
+  //   };
+  // }, [code, state]);
 
+  useEffect(() => {
+    async function loginWithNaver() {
+      const user = await loginNaver(data);
+      setuserIdState(user.id);
+    }
+
+    //loginWithNaver();
+    console.log(data);
     router.replace('/');
   }, []);
   return <div />;
@@ -30,22 +46,9 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     state: state as string,
   };
 
-  try {
-    const res = await loginNaver(data);
-
-    return {
-      props: {
-        user: res,
-      },
-    };
-  } catch (e) {
-    console.log(e);
-  }
-
   return {
-    redirect: {
-      destination: '/',
-      permanent: false,
+    props: {
+      data,
     },
   };
 };

--- a/src/recoils/atoms/users.ts
+++ b/src/recoils/atoms/users.ts
@@ -1,4 +1,3 @@
-import { IUser } from './../api/types/users/index';
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
@@ -9,14 +8,8 @@ export const loginPopupState = atom({
   default: false,
 });
 
-export const loginState = atom({
-  key: 'loginState',
-  default: false,
-  effects_UNSTABLE: [persistAtom],
-});
-
-export const userInfoState = atom<IUser | null>({
-  key: 'userInfoState',
+export const userIdState = atom<number | null>({
+  key: 'userIdState',
   default: null,
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/recoils/selector/users.ts
+++ b/src/recoils/selector/users.ts
@@ -1,0 +1,11 @@
+import { selector } from 'recoil';
+import { userIdState } from '../atoms/users';
+
+export const loginState = selector({
+  key: 'loginState',
+  get: ({ get }) => {
+    const userId = get(userIdState);
+
+    return !!userId;
+  },
+});


### PR DESCRIPTION
## PR 설명
- recoil에서 관리하던 로그인 유저정보는 따로 담지 않고, 로그인시 userId만 리코일에 저장하는 방식으로 바꿨습니다.
   마이페이지나 로그인 정보가 필요한 곳에서는 `useUser` hook을 사용하여 유저정보를 불러오면 될것같아요! 
- `recoil` 관련 파일들은 `recoil/atoms` 혹은 `recoil/selector` 로 옮겼습니다. 다른 프로젝트를 보면 이방식을 많이 사용하는 것 같더라구요! 혹시 원하는 방식이 있으면 고쳐도되용!!  